### PR TITLE
Add feature to allow permissions based opt-out of leashing

### DIFF
--- a/src/main/java/wm/vdr/leashplayers/Listeners.java
+++ b/src/main/java/wm/vdr/leashplayers/Listeners.java
@@ -44,6 +44,8 @@ public class Listeners implements Listener {
         Player target = (Player) e.getRightClicked();
 
         if(!player.hasPermission("leashplayers.use")) return;
+        //Gets if target is leashable
+        if(!target.hasPermission("leashplayers.leashable")) return;
 
         if(leashed.contains(target)) {
             leashed.remove(target);

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -18,4 +18,4 @@ permissions:
     default: op
   leashplayers.leashable:
     description: allow to be leashed.
-    default: op
+    default: not op

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -16,3 +16,6 @@ permissions:
   leashplayers.use:
     description: allow leash other player.
     default: op
+  leashplayers.leashable:
+    description: allow to be leashed.
+    default: op


### PR DESCRIPTION
I've added a feature to allow permissions based opt-out of leashing. This can be useful to keep OP's from leashing other OP's, or in the case where everyone is allowed to leash players, this allow for an opt-out for VIP's and OP's.

I've added another check under the one that checks permission for the player leashplayers.use to check the target has permission leashplayers.leashable. I also updated the plugin.yml to add the new permission.